### PR TITLE
chore(.github/workflow): ci.yml 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  build:
+    timeout-minutes: 15
+
+    runs-on: ubuntu-latest
+
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+    strategy:
+      matrix:
+        command: [lint, build]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm package manager
+        uses: pnpm/action-setup@v2
+        with:
+          run_install: false
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+          node-version-file: .nvmrc
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run commands
+        run: pnpm ${{ matrix.command }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  build:
+  quality:
     timeout-minutes: 15
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #17 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* [chore(.github/workflow): ci.yml 추가](https://github.com/dnd-side-project/dnd-10th-5-frontend/commit/0f4729cae11dde1f57e0b0cd52f4ac0143a64fae)

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

<img width="914" alt="image" src="https://github.com/dnd-side-project/dnd-10th-5-frontend/assets/66409882/8f7b9f6b-e538-42d4-a352-b1481fb79a6c">

* 현재 pnpm/action-setup 최신 버전에서 node16을 사용하고 있어 위와 같은 경고가 발생합니다! [github에서 deprecated 되는 node16을 사용하지 말고 node20을 사용하라는 것](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)에 대한 [pnpm/action-setup 레포 내부 관련 이슈](https://github.com/pnpm/action-setup/issues/99#issuecomment-1918361558)를 보니 pnpm/action-setup 내부적으로 node16에서 node20으로 넘어가지 못하는 기술적인 이슈가 있는 것 같습니다! 따라서 2024년 봄까지 node16을 지원하므로 기존 코드로 진행을 하고 node20으로 업데이트가 되지 않는다면 `corepack enable`과 같은 스크립트를 작성하는 것으로 대체를 할 생각입니다! 🙋🏻‍♂️

