### PR TITLE
chore(.github): label 자동 추가하는 action 생성

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,49 @@
+# labeler "full" schema
+
+# enable labeler on issues, prs, or both.
+enable:
+  issues: true
+  prs: true
+# comments object allows you to specify a different message for issues and prs
+
+comments:
+  issues: |
+    Thanks for opening this issue!
+    I have applied any labels matching special text in your title and description.
+
+    Please review the labels and make any necessary changes.
+  prs: |
+    Thanks for the contribution!
+    I have applied any labels matching special text in your title and description.
+
+    Please review the labels and make any necessary changes.
+
+# Labels is an object where:
+# - keys are labels
+# - values are objects of { include: [ pattern ], exclude: [ pattern ] }
+#    - pattern must be a valid regex, and is applied globally to
+#      title + description of issues and/or prs (see enabled config above)
+#    - 'include' patterns will associate a label if any of these patterns match
+#    - 'exclude' patterns will ignore this label if any of these patterns match
+labels:
+  bug:
+    include:
+      - '\bbug(?:\(.+\))?\b'
+  chore:
+    include:
+      - '\bchore(?:\(.+\))?\b'
+  docs:
+    include:
+      - '\bdocs(?:\(.+\))?\b'
+  feat:
+    include:
+      - '\bfeat(?:\(.+\))?\b'
+  fix:
+    include:
+      - '\bfix(?:\(.+\))?\b'
+  refactor:
+    include:
+      - '\brefactor(?:\(.+\))?\b'
+  style:
+    include:
+      - '\bstyle(?:\(.+\))?\b'

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -1,0 +1,19 @@
+name: Community
+
+on:
+  issues:
+    types: [opened, edited, milestoned]
+
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check labels
+        id: labeler
+        uses: jimschubert/labeler-action@v2
+        with:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #37 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* [chore(.github): label 자동 추가하는 action 생성](https://github.com/dnd-side-project/dnd-10th-5-frontend/commit/7002c223388085acee26295f36317236fe7ef0f1)

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* pr 혹은 issue 제목이나 본문 내용에 해당하는 문자열이 존재한다면 자동으로 label에 추가가 되도록 하는 github-action을 생성하였습니다! 저희와 같은 경우 제목 내부 feat, doc, chore 등등의 type을 보고 자동으로 할당되게 하는 것이 목적입니다! 🤔
