### PR TITLE
feat(shared/components): Icon 컴포넌트 추가

### DIFF
--- a/packages/shared/components/src/Icon.tsx
+++ b/packages/shared/components/src/Icon.tsx
@@ -1,0 +1,28 @@
+import { favolink, forwardRef } from '@favolink/system';
+import { classNames } from '@favolink/utils';
+import { type ComponentPropsWithoutRef } from 'react';
+
+const ICON_CLASSNAME = 'favolink-icon';
+
+export type IconProps = ComponentPropsWithoutRef<'svg'>;
+
+const Icon = forwardRef<IconProps, 'svg'>(function Icon(props, ref) {
+  const { as: element, children, className, ...restProps } = props;
+
+  const sharedProps = {
+    ref,
+    className: classNames(ICON_CLASSNAME, className),
+  };
+
+  if (element && typeof element !== 'string') {
+    return <favolink.svg as={element} {...sharedProps} {...restProps} />;
+  }
+
+  return (
+    <favolink.svg {...sharedProps} {...restProps}>
+      {children}
+    </favolink.svg>
+  );
+});
+
+export default Icon;

--- a/packages/shared/components/src/index.ts
+++ b/packages/shared/components/src/index.ts
@@ -4,6 +4,7 @@ export * from '@favolink/system';
 export { default as Box } from './Box';
 export { default as Button, type ButtonProps } from './Button';
 export { default as Heading, type HeadingProps } from './Heading';
+export { default as Icon, type IconProps } from './Icon';
 export { default as Link, type LinkProps } from './Link';
 export {
   default as Modal,


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #86 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* [feat(shared/components): Icon 컴포넌트 추가](https://github.com/dnd-side-project/dnd-10th-5-frontend/commit/115cc13c49659d939925a27b890cd9f7c426c7b3)

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* Icon 컴포넌트는 두 가지 케이스로 반환합니다!
* as prop의 type이 string 즉 div, a 태그와 같은 것이 아닐 경우 이미 만들어진 React.ReactNode의 형식인 경우 형식 그대로 반환합니다!
* 위 경우가 아닌 경우 children 값들을 자식 element로 하여 반환합니다!
* 추후 props 없이 Icon 컴포넌트를 사용한 경우를 의미하는 fallback 요소를 추가할 계획입니다!
