### PR TITLE
refactor(shared/components/Toast, shared/stores/toast): Provider를 ToastProvider로 변경, showToast link 기본값 설정

### DIFF
--- a/packages/shared/components/src/Provider.tsx
+++ b/packages/shared/components/src/Provider.tsx
@@ -1,11 +1,11 @@
 import { type ReactNode } from 'react';
-import Toast from './Toast';
+import { ToastProvider } from './Toast';
 
 export default function Provider({ children }: { children: ReactNode }) {
   return (
     <>
       {children}
-      <Toast.Provider />
+      <ToastProvider />
     </>
   );
 }

--- a/packages/shared/components/src/Toast/index.tsx
+++ b/packages/shared/components/src/Toast/index.tsx
@@ -9,7 +9,7 @@ import Portal from '../Portal';
 
 const TOAST_CLASSNAME = 'favolink-toast';
 
-function Provider() {
+export function ToastProvider() {
   const toastState = useSyncExternalStore(
     toastStore.subscribe,
     toastStore.getState,
@@ -26,9 +26,7 @@ function Provider() {
   return <Portal type="toast">{toastList}</Portal>;
 }
 
-Toast.Provider = Provider;
-
-type ToastProps = Toast;
+export type ToastProps = Toast;
 
 export default function Toast(props: ToastProps) {
   const { id, message, duration, link } = props;

--- a/packages/shared/components/src/index.ts
+++ b/packages/shared/components/src/index.ts
@@ -34,4 +34,4 @@ export {
   type TagLabelProps,
 } from './Tag';
 export { default as Text, type TextProps } from './Text';
-export { default as Toast } from './Toast';
+export { default as Toast, type ToastProps, ToastProvider } from './Toast';

--- a/packages/shared/stores/src/toast.ts
+++ b/packages/shared/stores/src/toast.ts
@@ -38,12 +38,12 @@ export const toastStore: ToastStore = {
       listeners.delete(listener);
     };
   },
-  showToast: ({ message, duration = 2000, link }) => {
+  showToast: ({ message, duration = 2000, link = '' }) => {
     const newToast: Toast = {
       id: Date.now(),
       message,
       duration,
-      link: link ?? '',
+      link,
     };
 
     setState((prevState) => [...prevState, newToast]);


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #107 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* 합성 컴포넌트로 이루어진 Toast를 분리합니다! (Toast.Provider를 ToastProvider로 변경)
* toastStore에서 showToast의 link를 빈값('')로 초기화하여 존재하지 않을 경우의 기본값을 설정합니다!

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* 
