### PR TITLE
feat(shared/components/flex): flex 컴포넌트에 grow, shrink, basis 속성 추가, inline vars 사용 

### DIFF
--- a/packages/shared/components/src/layout/flex.styles.css.ts
+++ b/packages/shared/components/src/layout/flex.styles.css.ts
@@ -1,79 +1,26 @@
-import { style } from '@vanilla-extract/css';
-import { createCSSPropertyStyleVariants } from './create-css-property-style-variants';
+import { createVar, style } from '@vanilla-extract/css';
+
+export const flexJustify = createVar();
+
+export const flexAlign = createVar();
+
+export const flexWrap = createVar();
+
+export const flexDirection = createVar();
+
+export const flexBasis = createVar();
+
+export const flexShrink = createVar();
+
+export const flexGrow = createVar();
 
 export const flexBase = style({
   display: 'flex',
+  justifyContent: flexJustify,
+  alignItems: flexAlign,
+  flexWrap,
+  flexDirection,
+  flexBasis,
+  flexShrink,
+  flexGrow,
 });
-
-export const flexJustify = createCSSPropertyStyleVariants('justifyContent', [
-  '-moz-initial',
-  'center',
-  'end',
-  'flex-end',
-  'flex-start',
-  'inherit',
-  'initial',
-  'left',
-  'normal',
-  'revert',
-  'revert-layer',
-  'right',
-  'space-around',
-  'space-between',
-  'space-evenly',
-  'start',
-  'stretch',
-  'unset',
-]);
-
-export type FlexJustify = keyof typeof flexJustify;
-
-export const flexAlign = createCSSPropertyStyleVariants('alignItems', [
-  '-moz-initial',
-  'baseline',
-  'center',
-  'end',
-  'flex-end',
-  'flex-start',
-  'inherit',
-  'initial',
-  'normal',
-  'revert',
-  'revert-layer',
-  'self-end',
-  'self-start',
-  'start',
-  'stretch',
-  'unset',
-]);
-
-export type FlexAlign = keyof typeof flexAlign;
-
-export const flexWrap = createCSSPropertyStyleVariants('flexWrap', [
-  '-moz-initial',
-  'inherit',
-  'initial',
-  'nowrap',
-  'revert',
-  'revert-layer',
-  'unset',
-  'wrap',
-  'wrap-reverse',
-]);
-
-export type FlexWrap = keyof typeof flexWrap;
-
-export const flexDirection = createCSSPropertyStyleVariants('flexDirection', [
-  '-moz-initial',
-  'column',
-  'column-reverse',
-  'inherit',
-  'initial',
-  'revert',
-  'revert-layer',
-  'row',
-  'row-reverse',
-  'unset',
-]);
-
-export type FlexDirection = keyof typeof flexDirection;

--- a/packages/shared/components/src/layout/flex.tsx
+++ b/packages/shared/components/src/layout/flex.tsx
@@ -1,12 +1,17 @@
 import { type HTMLFavolinkProps, favolink, forwardRef } from '@favolink/system';
 import { classNames } from '@favolink/utils';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import { type CSSProperties } from 'react';
 import * as styles from './flex.styles.css';
 
 type FlexOptions = {
-  justify?: styles.FlexJustify;
-  align?: styles.FlexAlign;
-  wrap?: styles.FlexWrap;
-  direction?: styles.FlexDirection;
+  justify?: CSSProperties['justifyContent'];
+  align?: CSSProperties['alignItems'];
+  wrap?: CSSProperties['flexWrap'];
+  direction?: CSSProperties['flexDirection'];
+  grow?: CSSProperties['flexGrow'];
+  shrink?: CSSProperties['flexShrink'];
+  basis?: CSSProperties['flexBasis'];
 };
 
 export type FlexProps = FlexOptions & HTMLFavolinkProps<'div'>;
@@ -15,10 +20,14 @@ export const Flex = forwardRef<FlexProps, 'div'>(function Flex(props, ref) {
   const {
     children,
     className,
-    justify = 'normal',
-    align = 'normal',
-    wrap = 'nowrap',
-    direction = 'row',
+    style,
+    justify,
+    align,
+    wrap,
+    direction,
+    grow,
+    shrink,
+    basis,
     ...restProps
   } = props;
 
@@ -26,14 +35,19 @@ export const Flex = forwardRef<FlexProps, 'div'>(function Flex(props, ref) {
     <favolink.div
       {...restProps}
       ref={ref}
-      className={classNames(
-        styles.flexBase,
-        styles.flexJustify[justify],
-        styles.flexAlign[align],
-        styles.flexWrap[wrap],
-        styles.flexDirection[direction],
-        className,
-      )}
+      className={classNames(styles.flexBase, className)}
+      style={{
+        ...assignInlineVars({
+          [styles.flexJustify]: justify,
+          [styles.flexAlign]: align,
+          [styles.flexWrap]: wrap,
+          [styles.flexDirection]: direction,
+          [styles.flexShrink]: String(shrink),
+          [styles.flexBasis]: String(basis),
+          [styles.flexGrow]: String(grow),
+        }),
+        ...style,
+      }}
     >
       {children}
     </favolink.div>


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #139 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* styles 내부 createVars를 사용한 값으로 모두 변경합니다!
* grow, shrink, basis 속성을 추가하고, inline vars를 사용한 것으로 통일하여 변경합니다!

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* 현재 flex 관련 속성들을 하나씩 구조 분해하여 사용하고 있지만 `extractProps`와 같은 이름의 prop들을 순회하여 특정 prop에 해당하는 과정을 진행하는 것을 자동화하는 함수를 만들어보면 어떨까 생각중입니다!