### PR TITLE
feat(shared/system): StyleProps 타입, createRawStyleProps 함수 추가

### DIFF
--- a/packages/shared/system/src/create-raw-style-props.ts
+++ b/packages/shared/system/src/create-raw-style-props.ts
@@ -1,0 +1,14 @@
+import { type CSSProperties } from 'react';
+
+export type StyleProps<Props extends keyof CSSProperties> = {
+  [key in Props]?: CSSProperties[key];
+};
+
+export function createRawStyleProps<
+  Props extends StyleProps<keyof CSSProperties>,
+>(...styleProps: (keyof Props)[]) {
+  return styleProps.reduce(
+    (acc, styleProp) => ({ ...acc, [styleProp]: undefined }),
+    {} as Record<keyof Props, undefined>,
+  );
+}

--- a/packages/shared/system/src/index.ts
+++ b/packages/shared/system/src/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @stylistic/padding-line-between-statements */
 export * from './create-component';
 export * from './create-context';
+export * from './create-raw-style-props';
 export * from './factory';
 export * from './forward-ref';
 export * from './types';


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #155 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* StyleProps 타입, createRawStyleProps 함수 추가합니다!

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

### 사용법

```ts
import { type StyleProps, createRawStyleProps } from '@favolink/system';

export type FlexStyleProps = StyleProps<
  | 'alignItems'
  | 'flexBasis'
  | 'flexDirection'
  | 'flexGrow'
  | 'flexShrink'
  | 'flexWrap'
  | 'justifyContent'
>;

export const flexStyleProps = createRawStyleProps<FlexStyleProps>(
  'alignItems',
  'flexBasis',
  'flexDirection',
  'flexGrow',
  'flexShrink',
  'flexWrap',
  'justifyContent',
);

```
flex에 대한 style prop들을 정의하고자 할 경우 위와 같이 사용할 수 있습니다!

![image](https://github.com/dnd-side-project/dnd-10th-5-frontend/assets/66409882/9839ed0d-030c-47d5-a9a9-6f50dac7d20c)
![image](https://github.com/dnd-side-project/dnd-10th-5-frontend/assets/66409882/8039a9e4-bdc9-4ae6-83cd-7a185fafdb5c)

타입은 위와 같이 정의됩니다!
flexStyleProps의 타입이 Record로 정의한 이유는 인자 내부에 FlexStyleProps로 정의한 key들이 전부 다 들어가지 않을 수 있기 때문에 혼란을 방지하고자 하였습니다!