### PR TITLE
refactor(shared/components/layout/flex): Flex 컴포넌트에 extractProps 추가, flex.styles.css.ts 내부 flexStyleVars 사용

### DIFF
--- a/packages/shared/components/src/layout/flex.styles.css.ts
+++ b/packages/shared/components/src/layout/flex.styles.css.ts
@@ -1,26 +1,7 @@
-import { createVar, style } from '@vanilla-extract/css';
-
-export const flexJustify = createVar();
-
-export const flexAlign = createVar();
-
-export const flexWrap = createVar();
-
-export const flexDirection = createVar();
-
-export const flexBasis = createVar();
-
-export const flexShrink = createVar();
-
-export const flexGrow = createVar();
+import { flexStyleVars } from '@favolink/styles';
+import { style } from '@vanilla-extract/css';
 
 export const flexBase = style({
   display: 'flex',
-  justifyContent: flexJustify,
-  alignItems: flexAlign,
-  flexWrap,
-  flexDirection,
-  flexBasis,
-  flexShrink,
-  flexGrow,
+  ...flexStyleVars,
 });

--- a/packages/shared/components/src/layout/flex.tsx
+++ b/packages/shared/components/src/layout/flex.tsx
@@ -1,53 +1,31 @@
-import { type HTMLFavolinkProps, favolink, forwardRef } from '@favolink/system';
+import {
+  type FlexStyleProps,
+  flexStyleProps,
+  flexStyleVars,
+} from '@favolink/styles';
+import {
+  type HTMLFavolinkProps,
+  extractProps,
+  favolink,
+  forwardRef,
+} from '@favolink/system';
 import { cx } from '@favolink/utils';
-import { assignInlineVars } from '@vanilla-extract/dynamic';
-import { type CSSProperties } from 'react';
 import * as styles from './flex.styles.css';
 
-type FlexOptions = {
-  justify?: CSSProperties['justifyContent'];
-  align?: CSSProperties['alignItems'];
-  wrap?: CSSProperties['flexWrap'];
-  direction?: CSSProperties['flexDirection'];
-  grow?: CSSProperties['flexGrow'];
-  shrink?: CSSProperties['flexShrink'];
-  basis?: CSSProperties['flexBasis'];
-};
-
-export type FlexProps = FlexOptions & HTMLFavolinkProps<'div'>;
+export type FlexProps = FlexStyleProps & HTMLFavolinkProps<'div'>;
 
 export const Flex = forwardRef<FlexProps, 'div'>(function Flex(props, ref) {
-  const {
-    children,
-    className,
-    style,
-    justify,
-    align,
-    wrap,
-    direction,
-    grow,
-    shrink,
-    basis,
-    ...restProps
-  } = props;
+  const { children, className, ...restProps } = extractProps(
+    props,
+    flexStyleVars,
+    flexStyleProps,
+  );
 
   return (
     <favolink.div
       {...restProps}
       ref={ref}
       className={cx(styles.flexBase, className)}
-      style={{
-        ...assignInlineVars({
-          [styles.flexJustify]: justify,
-          [styles.flexAlign]: align,
-          [styles.flexWrap]: wrap,
-          [styles.flexDirection]: direction,
-          [styles.flexShrink]: String(shrink),
-          [styles.flexBasis]: String(basis),
-          [styles.flexGrow]: String(grow),
-        }),
-        ...style,
-      }}
     >
       {children}
     </favolink.div>


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #143 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* flex.styles.css.ts 내부 createVar을 통해 만든 var들을 flexStyleVars로 변경합니다.
* Flex 컴포넌트 내부 props을 객체 구조 분해하던 것을 extractProps 함수를 사용하는 것으로 변경합니다.

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* 
