### PR TITLE
feat(ui/hooks): usePosition 훅 추가

### DIFF
--- a/packages/ui/hooks/src/index.ts
+++ b/packages/ui/hooks/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @stylistic/padding-line-between-statements */
 export { useBoolean } from './use-boolean';
 export { useDisclosure } from './use-disclosure';
+export { usePosition, type Placement } from './use-position';
 export { useScroll } from './use-scroll';

--- a/packages/ui/hooks/src/use-position.ts
+++ b/packages/ui/hooks/src/use-position.ts
@@ -1,0 +1,103 @@
+import {
+  type CSSProperties,
+  type MutableRefObject,
+  useEffect,
+  useState,
+} from 'react';
+import { useScroll } from './use-scroll';
+
+type Layout = 'bottom' | 'left' | 'right' | 'top';
+
+type Side = 'end' | 'start';
+
+export type Placement = Layout | `${Layout}-${Side}`;
+
+export function usePosition(
+  ref: MutableRefObject<any> | null,
+  placement: Placement = 'bottom',
+) {
+  const [rect, setRect] = useState<CSSProperties>({});
+  const { scrollX, scrollY } = useScroll();
+
+  const heightScrollbarWidth =
+    window.innerWidth - document.documentElement.clientWidth;
+  const widthScrollbarHeight =
+    window.innerHeight - document.documentElement.clientHeight;
+  const screenWidth = window.innerWidth - heightScrollbarWidth;
+  const screenHeight = window.innerHeight - widthScrollbarHeight;
+
+  useEffect(() => {
+    if (!ref) {
+      return;
+    }
+
+    const { top, right, bottom, left } = (
+      ref as MutableRefObject<HTMLElement>
+    ).current.getBoundingClientRect();
+
+    switch (placement) {
+      case 'bottom':
+      case 'bottom-start':
+        setRect({
+          top: bottom,
+          left,
+        });
+
+        break;
+      case 'bottom-end':
+        setRect({
+          top: bottom,
+          right: screenWidth - right,
+        });
+
+        break;
+      case 'left':
+      case 'left-start':
+        setRect({
+          top,
+          right: screenWidth - left,
+        });
+
+        break;
+      case 'left-end':
+        setRect({
+          bottom: screenHeight - bottom,
+          right: screenWidth - left,
+        });
+
+        break;
+      case 'right':
+      case 'right-start':
+        setRect({
+          top,
+          left: right,
+        });
+
+        break;
+      case 'right-end':
+        setRect({
+          bottom: screenHeight - bottom,
+          left: right,
+        });
+
+        break;
+      case 'top':
+      case 'top-start':
+        setRect({
+          bottom: screenHeight - top,
+          left: left,
+        });
+
+        break;
+      case 'top-end':
+        setRect({
+          bottom: screenHeight - top,
+          right: screenWidth - right,
+        });
+
+        break;
+    }
+  }, [ref, placement, screenWidth, screenHeight, scrollX, scrollY]);
+
+  return rect as Record<Layout, number>;
+}


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #193 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* usePosition 훅을 추가합니다.

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* 인자로 `ref`, `placement`를 받습니다.
  * `placement`에는 `right`, `left`, `top`, `bottom` 그리고 각 layout에 `start`, `end` 즉 side를 prefix로 붙인 값을 받을 수 있습니다.
  * ref에는 domElement 관련 ref를 받습니다.
* `useScroll` 을 사용하여 `scrollX` `scrollY`의 실시간 값을 받습니다.
  * `useEffect` 내부 의존성 배열에 `scrollX`, `scrollY`를 추가하여 scroll에 따른 `rect` 값이 업데이트될 수 있도록 합니다. 
