### PR TITLE
feat(ui/system): slottable 개념 도입

### DIFF
--- a/packages/ui/system/src/create-polymorphic-component.ts
+++ b/packages/ui/system/src/create-polymorphic-component.ts
@@ -3,17 +3,26 @@ import {
   Children,
   type ComponentPropsWithoutRef,
   type ElementType,
+  type ReactElement,
+  type ReactNode,
   type Ref,
   cloneElement,
   createElement,
   isValidElement,
 } from 'react';
 import { forwardRef } from './forward-ref';
+import { Slottable, type SlottableProps } from './slottable';
 import {
   type ComponentWithPolymorphic,
   type JsxElements,
   type PolymorphicProps,
 } from './types';
+
+export function isSlottable(
+  child: ReactNode,
+): child is ReactElement<SlottableProps> {
+  return isValidElement(child) && child.type === Slottable;
+}
 
 export type FavolinkComponent<Component extends ElementType> =
   ComponentWithPolymorphic<Component, object>;
@@ -34,6 +43,43 @@ export function createPolymorphicComponent<Component extends ElementType>(
           },
           children,
         );
+      }
+
+      const childrenArray = Children.toArray(children);
+      const slottable = childrenArray.find(isSlottable);
+
+      if (slottable) {
+        const newElement = slottable.props.children;
+        const newChildren = childrenArray.map((child) => {
+          if (child === slottable) {
+            if (Children.count(newElement) > 1) {
+              return Children.only(null);
+            }
+
+            return isValidElement(newElement)
+              ? ((newElement as ReactElement<{ children: ReactNode }>).props
+                  .children as ReactNode)
+              : null;
+          } else {
+            return child;
+          }
+        });
+
+        return isValidElement(newElement)
+          ? cloneElement(
+              newElement as ReactElement,
+              {
+                ...mergeProps(restProps, newElement.props),
+                ref: ref
+                  ? composeRefs(
+                      ref,
+                      (newElement as ReactElement & { ref: Ref<any> }).ref,
+                    )
+                  : (newElement as ReactElement & { ref: Ref<any> }).ref,
+              },
+              newChildren,
+            )
+          : null;
       }
 
       const onlyChild = Children.only(children);

--- a/packages/ui/system/src/index.ts
+++ b/packages/ui/system/src/index.ts
@@ -4,4 +4,5 @@ export * from './create-polymorphic-component';
 export * from './create-raw-style-props';
 export * from './factory';
 export * from './forward-ref';
+export * from './slottable';
 export * from './types';

--- a/packages/ui/system/src/slottable.tsx
+++ b/packages/ui/system/src/slottable.tsx
@@ -1,0 +1,5 @@
+import { type ReactNode } from 'react';
+
+export function Slottable({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/packages/ui/system/src/slottable.tsx
+++ b/packages/ui/system/src/slottable.tsx
@@ -1,5 +1,11 @@
 import { type ReactNode } from 'react';
 
-export function Slottable({ children }: { children: ReactNode }) {
+export type SlottableProps = {
+  children: ReactNode;
+};
+
+export function Slottable(props: SlottableProps) {
+  const { children } = props;
+
   return children;
 }


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #198 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* Slottable 컴포넌트를 추가합니다.
* Slottable 개념을 createPolymorphicComponent 함수에 적용합니다.

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* 기존 onlyChild일 경우 즉 children 내부 element가 하나일 경우만 asChild가 가능하도록 하였습니다. 하지만 slottable 개념을 도입하여 children의 element가 여러개더라도 <Slottable /> 컴포넌트 내부 children(이것 또한 element가 하나인 경우)을 asChild로 받아서 동작하도록 합니다.
