### PR TITLE
feat(ui/react/button): Button 컴포넌트에 rightElement, leftElement를 포함한 속성들 추가

### DIFF
--- a/packages/ui/react/src/components/button/button.styles.css.ts
+++ b/packages/ui/react/src/components/button/button.styles.css.ts
@@ -57,7 +57,7 @@ export const buttonVariants = recipe({
       normal: [body3Regular],
       strength: [h6SemiBold],
     },
-    radius: {
+    rounded: {
       full: {
         borderRadius: 9999,
       },
@@ -65,8 +65,8 @@ export const buttonVariants = recipe({
         borderRadius: 8,
       },
     },
-    fullfill: {
-      true: {
+    width: {
+      full: {
         width: '100%',
       },
     },
@@ -75,8 +75,8 @@ export const buttonVariants = recipe({
     justify: 'center',
     variant: 'solid',
     text: 'normal',
-    radius: 'normal',
-    fullfill: false,
+    rounded: 'normal',
+    width: undefined,
   },
 });
 

--- a/packages/ui/react/src/components/button/button.styles.css.ts
+++ b/packages/ui/react/src/components/button/button.styles.css.ts
@@ -1,47 +1,119 @@
+import {
+  type ComplexStyleRule,
+  style,
+  styleVariants,
+} from '@vanilla-extract/css';
 import { type RecipeVariants, recipe } from '@vanilla-extract/recipes';
-import { h5Bold, h6SemiBold } from '../../styles/text.css';
+import { type CSSProperties } from 'react';
+import { body3Regular, h6SemiBold } from '../../styles/text.css';
 import { vars } from '../../styles/vars.css';
 
-export const button = recipe({
+function makeButtonArchiveColorScheme(
+  color: CSSProperties['color'],
+): ComplexStyleRule {
+  return {
+    selectors: {
+      [`${buttonVariant.solid}&`]: {
+        backgroundColor: color,
+        border: `1px solid ${color}`,
+        color: color === 'white' ? vars.color.gray[1100] : 'white',
+      },
+      [`${buttonVariant.outline}&`]: {
+        color: vars.color.gray[1100],
+        backgroundColor: 'inherit',
+        border: `1px solid ${color}`,
+      },
+    },
+  };
+}
+
+export const buttonVariants = recipe({
   base: {
-    borderRadius: 8,
+    display: 'inline-flex',
+    alignItems: 'center',
     cursor: 'pointer',
+    textDecoration: 'none',
+    boxSizing: 'border-box',
+    appearance: 'none',
+    verticalAlign: 'middle',
+    whiteSpace: 'nowrap',
+    padding: '8px 10px',
+    minWidth: 72,
   },
-
   variants: {
-    colorScheme: {
-      gray: {
-        backgroundColor: vars.color.gray[400],
-        border: `1px solid ${vars.color.gray[400]}`,
-        color: vars.color.gray[200],
+    justify: {
+      center: {
+        justifyContent: 'center',
       },
-      black: {
-        backgroundColor: vars.color.gray[1000],
-        border: `1px solid ${vars.color.gray[1000]}`,
-        color: 'white',
-      },
-      white: {
-        backgroundColor: 'white',
-        border: `1px solid ${vars.color.gray[300]}`,
-        color: vars.color.gray[900],
-      },
-      red: {
-        backgroundColor: vars.color.system[300],
-        border: `1px solid ${vars.color.system[300]}`,
-        color: 'white',
+      start: {
+        justifyContent: 'start',
       },
     },
-    size: {
-      small: [h6SemiBold, { minWidth: 100, minHeight: 30 }],
-      medium: [h6SemiBold, { minWidth: 202, minHeight: 40 }],
-      large: [h5Bold, { minWidth: 332, minHeight: 44 }],
+    variant: {
+      solid: {},
+      outline: {},
+    },
+    text: {
+      normal: [body3Regular],
+      strength: [h6SemiBold],
+    },
+    radius: {
+      full: {
+        borderRadius: 9999,
+      },
+      normal: {
+        borderRadius: 8,
+      },
+    },
+    fullfill: {
+      true: {
+        width: '100%',
+      },
     },
   },
-
   defaultVariants: {
-    colorScheme: 'white',
-    size: 'medium',
+    justify: 'center',
+    variant: 'solid',
+    text: 'normal',
+    radius: 'normal',
+    fullfill: false,
   },
 });
 
-export type ButtonVariants = RecipeVariants<typeof button>;
+export type ButtonVariants = RecipeVariants<typeof buttonVariants>;
+
+const { variant: buttonVariant } = buttonVariants.classNames.variants;
+
+export const buttonColorScheme = styleVariants({
+  archiveBlack: makeButtonArchiveColorScheme(vars.color.archive.black),
+  archiveBlue: makeButtonArchiveColorScheme(vars.color.archive.blue),
+  archiveBrightGreen: makeButtonArchiveColorScheme(
+    vars.color.archive.brightGreen,
+  ),
+  archiveCoral: makeButtonArchiveColorScheme(vars.color.archive.coral),
+  archiveMint: makeButtonArchiveColorScheme(vars.color.archive.mint),
+  archivePink: makeButtonArchiveColorScheme(vars.color.archive.mint),
+  archivePurple: makeButtonArchiveColorScheme(vars.color.archive.purple),
+  archiveYellow: makeButtonArchiveColorScheme(vars.color.archive.yellow),
+  black: makeButtonArchiveColorScheme(vars.color.gray[1000]),
+  gray: makeButtonArchiveColorScheme(vars.color.gray[400]),
+  white: makeButtonArchiveColorScheme('white'),
+  red: makeButtonArchiveColorScheme(vars.color.system[300]),
+});
+
+export type ButtonColorScheme = keyof typeof buttonColorScheme;
+
+export const buttonHasElement = style({
+  gap: 10,
+});
+
+export const justifyStartButtonHasRightElement = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  selectors: {
+    [`${buttonVariants.classNames.variants.justify.start} &`]: {
+      flexGrow: 1,
+      justifyContent: 'flex-end',
+    },
+  },
+});

--- a/packages/ui/react/src/components/button/button.tsx
+++ b/packages/ui/react/src/components/button/button.tsx
@@ -24,10 +24,10 @@ export const Button = forwardRef<ButtonProps, 'button'>(
       className,
       rightElement,
       leftElement,
-      radius,
-      variant,
-      fullfill,
       justify,
+      variant,
+      rounded,
+      width,
       text,
       colorScheme = 'white',
       ...restProps
@@ -43,9 +43,9 @@ export const Button = forwardRef<ButtonProps, 'button'>(
         className={cx(
           'favolink-button',
           styles.buttonVariants({
-            radius,
+            rounded,
             variant,
-            fullfill,
+            width,
             justify,
             text,
           }),

--- a/packages/ui/react/src/components/button/button.tsx
+++ b/packages/ui/react/src/components/button/button.tsx
@@ -1,28 +1,64 @@
 import {
   type HTMLFavolinkProps,
+  Slottable,
   favolink,
   forwardRef,
 } from '@favolink-ui/system';
 import { cx } from '@favolink-ui/utils';
+import { type ReactElement } from 'react';
 import * as styles from './button.styles.css';
 
-export type ButtonProps = HTMLFavolinkProps<'button'> & styles.ButtonVariants;
+type ExtendedButtonProps = {
+  rightElement?: ReactElement;
+  leftElement?: ReactElement;
+};
+
+export type ButtonProps = ExtendedButtonProps &
+  HTMLFavolinkProps<'button'> &
+  styles.ButtonVariants & { colorScheme?: styles.ButtonColorScheme };
 
 export const Button = forwardRef<ButtonProps, 'button'>(
   function Button(props, ref) {
-    const { children, className, colorScheme, size, ...restProps } = props;
+    const {
+      children,
+      className,
+      rightElement,
+      leftElement,
+      radius,
+      variant,
+      fullfill,
+      justify,
+      text,
+      colorScheme = 'white',
+      ...restProps
+    } = props;
+
+    const hasElement = Boolean(rightElement || leftElement);
 
     return (
       <favolink.button
+        type="button"
         {...restProps}
         ref={ref}
         className={cx(
           'favolink-button',
-          styles.button({ size, colorScheme }),
+          styles.buttonVariants({
+            radius,
+            variant,
+            fullfill,
+            justify,
+            text,
+          }),
+          styles.buttonColorScheme[colorScheme],
+          hasElement && styles.buttonHasElement,
           className,
         )}
       >
-        {children}
+        {leftElement}
+        <Slottable>{children}</Slottable>
+        <span className={cx(styles.justifyStartButtonHasRightElement)}>
+          {rightElement}
+        </span>
       </favolink.button>
     );
   },


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #197 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* rightElement, leftElement를 포함하여 radius, variant, fullfill, justify, width, rounded와 같은 속성을 추가합니다.
* rightElement, leftElement가 children에 포함되어있기 때문에 Button 컴포넌트 내부 Slottable 컴포넌트로 감쌉니다. 

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* 
