### PR TITLE
feat(ui/react/button): buttonVaraints의 colorScheme에 대한 var 추가

### DIFF
--- a/packages/ui/react/src/components/button/button.styles.css.ts
+++ b/packages/ui/react/src/components/button/button.styles.css.ts
@@ -1,46 +1,53 @@
-import {
-  type ComplexStyleRule,
-  style,
-  styleVariants,
-} from '@vanilla-extract/css';
+import { type ComplexStyleRule, createVar, style } from '@vanilla-extract/css';
 import { type RecipeVariants, recipe } from '@vanilla-extract/recipes';
 import { type CSSProperties } from 'react';
 import { body3Regular, h6SemiBold } from '../../styles/text.css';
 import { vars } from '../../styles/vars.css';
 
-function makeButtonArchiveColorScheme(
+function makeButtonColorSchemeVar(
   color: CSSProperties['color'],
 ): ComplexStyleRule {
   return {
-    selectors: {
-      [`${buttonVariant.solid}&`]: {
-        backgroundColor: color,
-        border: `1px solid ${color}`,
-        color: color === 'white' ? vars.color.gray[1100] : 'white',
-      },
-      [`${buttonVariant.outline}&`]: {
-        color: vars.color.gray[1100],
-        backgroundColor: 'inherit',
-        border: `1px solid ${color}`,
-      },
+    vars: {
+      [colorScheme]: color as string,
     },
   };
 }
 
+const colorScheme = createVar();
+
+const base = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  cursor: 'pointer',
+  textDecoration: 'none',
+  boxSizing: 'border-box',
+  appearance: 'none',
+  verticalAlign: 'middle',
+  whiteSpace: 'nowrap',
+  padding: '8px 10px',
+  minWidth: 72,
+});
+
 export const buttonVariants = recipe({
-  base: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    cursor: 'pointer',
-    textDecoration: 'none',
-    boxSizing: 'border-box',
-    appearance: 'none',
-    verticalAlign: 'middle',
-    whiteSpace: 'nowrap',
-    padding: '8px 10px',
-    minWidth: 72,
-  },
+  base,
   variants: {
+    colorScheme: {
+      archiveBlack: makeButtonColorSchemeVar(vars.color.archive.black),
+      archiveBlue: makeButtonColorSchemeVar(vars.color.archive.blue),
+      archiveBrightGreen: makeButtonColorSchemeVar(
+        vars.color.archive.brightGreen,
+      ),
+      archiveCoral: makeButtonColorSchemeVar(vars.color.archive.coral),
+      archiveMint: makeButtonColorSchemeVar(vars.color.archive.mint),
+      archivePink: makeButtonColorSchemeVar(vars.color.archive.mint),
+      archivePurple: makeButtonColorSchemeVar(vars.color.archive.purple),
+      archiveYellow: makeButtonColorSchemeVar(vars.color.archive.yellow),
+      black: makeButtonColorSchemeVar(vars.color.gray[1000]),
+      gray: makeButtonColorSchemeVar(vars.color.gray[400]),
+      white: makeButtonColorSchemeVar('white'),
+      red: makeButtonColorSchemeVar(vars.color.system[300]),
+    },
     justify: {
       center: {
         justifyContent: 'center',
@@ -50,8 +57,16 @@ export const buttonVariants = recipe({
       },
     },
     variant: {
-      solid: {},
-      outline: {},
+      solid: {
+        backgroundColor: colorScheme,
+        border: `1px solid ${colorScheme}`,
+        color: 'white',
+      },
+      outline: {
+        color: vars.color.gray[1100],
+        backgroundColor: 'inherit',
+        border: `1px solid ${colorScheme}`,
+      },
     },
     text: {
       normal: [body3Regular],
@@ -72,36 +87,27 @@ export const buttonVariants = recipe({
     },
   },
   defaultVariants: {
+    colorScheme: 'white',
     justify: 'center',
     variant: 'solid',
     text: 'normal',
     rounded: 'normal',
     width: undefined,
   },
+  compoundVariants: [
+    {
+      variants: {
+        colorScheme: 'white',
+        variant: 'solid',
+      },
+      style: {
+        color: vars.color.gray[1100],
+      },
+    },
+  ],
 });
 
 export type ButtonVariants = RecipeVariants<typeof buttonVariants>;
-
-const { variant: buttonVariant } = buttonVariants.classNames.variants;
-
-export const buttonColorScheme = styleVariants({
-  archiveBlack: makeButtonArchiveColorScheme(vars.color.archive.black),
-  archiveBlue: makeButtonArchiveColorScheme(vars.color.archive.blue),
-  archiveBrightGreen: makeButtonArchiveColorScheme(
-    vars.color.archive.brightGreen,
-  ),
-  archiveCoral: makeButtonArchiveColorScheme(vars.color.archive.coral),
-  archiveMint: makeButtonArchiveColorScheme(vars.color.archive.mint),
-  archivePink: makeButtonArchiveColorScheme(vars.color.archive.mint),
-  archivePurple: makeButtonArchiveColorScheme(vars.color.archive.purple),
-  archiveYellow: makeButtonArchiveColorScheme(vars.color.archive.yellow),
-  black: makeButtonArchiveColorScheme(vars.color.gray[1000]),
-  gray: makeButtonArchiveColorScheme(vars.color.gray[400]),
-  white: makeButtonArchiveColorScheme('white'),
-  red: makeButtonArchiveColorScheme(vars.color.system[300]),
-});
-
-export type ButtonColorScheme = keyof typeof buttonColorScheme;
 
 export const buttonHasElement = style({
   gap: 10,

--- a/packages/ui/react/src/components/button/button.tsx
+++ b/packages/ui/react/src/components/button/button.tsx
@@ -8,14 +8,11 @@ import { cx } from '@favolink-ui/utils';
 import { type ReactElement } from 'react';
 import * as styles from './button.styles.css';
 
-type ExtendedButtonProps = {
-  rightElement?: ReactElement;
-  leftElement?: ReactElement;
-};
-
-export type ButtonProps = ExtendedButtonProps &
-  HTMLFavolinkProps<'button'> &
-  styles.ButtonVariants & { colorScheme?: styles.ButtonColorScheme };
+export type ButtonProps = HTMLFavolinkProps<'button'> &
+  styles.ButtonVariants & {
+    rightElement?: ReactElement;
+    leftElement?: ReactElement;
+  };
 
 export const Button = forwardRef<ButtonProps, 'button'>(
   function Button(props, ref) {
@@ -24,12 +21,12 @@ export const Button = forwardRef<ButtonProps, 'button'>(
       className,
       rightElement,
       leftElement,
+      colorScheme,
       justify,
       variant,
+      text,
       rounded,
       width,
-      text,
-      colorScheme = 'white',
       ...restProps
     } = props;
 
@@ -43,13 +40,13 @@ export const Button = forwardRef<ButtonProps, 'button'>(
         className={cx(
           'favolink-button',
           styles.buttonVariants({
-            rounded,
-            variant,
-            width,
+            colorScheme,
             justify,
+            variant,
             text,
+            rounded,
+            width,
           }),
-          styles.buttonColorScheme[colorScheme],
           hasElement && styles.buttonHasElement,
           className,
         )}


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #202 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* 기존 styleVariants로 colorScheme를 생성한 것에서 selector로 스타일을 정의했는데 vanilla-extract의 `createVar()`의 결과인 var를 활용하는 것으로 변경합니다.


## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* 
