### PR TITLE
feat(ui/react): Menu 컴포넌트 추가

### DIFF
--- a/packages/ui/react/src/components/menu/index.tsx
+++ b/packages/ui/react/src/components/menu/index.tsx
@@ -1,0 +1,6 @@
+/* eslint-disable @stylistic/padding-line-between-statements, react-refresh/only-export-components */
+export { Menu, type MenuProps } from './menu';
+export { MenuContent, type MenuContentProps } from './menu-content';
+export { MenuPortal, type MenuPortalProps } from './menu-portal';
+export { MenuTrigger, type MenuTriggerProps } from './menu-trigger';
+export { MenuProvider, useMenuContext } from './menu.context';

--- a/packages/ui/react/src/components/menu/menu-content.styles.css.ts
+++ b/packages/ui/react/src/components/menu/menu-content.styles.css.ts
@@ -1,0 +1,17 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+export const baseList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  position: 'fixed',
+  minWidth: 138,
+  boxShadow: '0 8px 20px 0 rgba(0, 0, 0, 0.25)',
+  borderRadius: 12,
+  padding: 16,
+  background: 'white',
+});
+
+export const listContainerisVisibility = styleVariants({
+  true: { visibility: 'visible', pointerEvents: 'auto' },
+  false: { visibility: 'hidden', pointerEvents: 'none' },
+});

--- a/packages/ui/react/src/components/menu/menu-content.tsx
+++ b/packages/ui/react/src/components/menu/menu-content.tsx
@@ -1,0 +1,52 @@
+import { type Placement, usePosition } from '@favolink-ui/hooks';
+import {
+  type HTMLFavolinkProps,
+  favolink,
+  forwardRef,
+} from '@favolink-ui/system';
+import { composeRefs, cx } from '@favolink-ui/utils';
+import * as styles from './menu-content.styles.css';
+import { useMenuContext } from './menu.context';
+
+export type MenuContentProps = HTMLFavolinkProps<'div'> & {
+  placement?: Placement;
+  sideOffset?: number;
+};
+
+export const MenuContent = forwardRef<MenuContentProps, 'div'>(
+  function MenuContent(props, ref) {
+    const {
+      children,
+      className,
+      placement = 'bottom',
+      sideOffset = 0,
+      style,
+      ...restProps
+    } = props;
+
+    const { open, triggerRef, containerRef } = useMenuContext();
+
+    const coordinate = usePosition(
+      triggerRef,
+      containerRef,
+      placement,
+      sideOffset,
+    );
+
+    return (
+      <favolink.div
+        {...restProps}
+        ref={composeRefs(ref, containerRef)}
+        className={cx(
+          `favolink-menu__list`,
+          styles.baseList,
+          styles.listContainerisVisibility[open ? 'true' : 'false'],
+          className,
+        )}
+        style={{ ...coordinate, ...style }}
+      >
+        {children}
+      </favolink.div>
+    );
+  },
+);

--- a/packages/ui/react/src/components/menu/menu-portal.tsx
+++ b/packages/ui/react/src/components/menu/menu-portal.tsx
@@ -1,0 +1,14 @@
+import { cx } from '@favolink-ui/utils';
+import { Portal, type PortalProps } from '../portal';
+
+export type MenuPortalProps = PortalProps;
+
+export function MenuPortal(props: PortalProps) {
+  const { children, className, ...restProps } = props;
+
+  return (
+    <Portal {...restProps} className={cx('favolink-menu__portal', className)}>
+      {children}
+    </Portal>
+  );
+}

--- a/packages/ui/react/src/components/menu/menu-trigger.tsx
+++ b/packages/ui/react/src/components/menu/menu-trigger.tsx
@@ -1,0 +1,29 @@
+import {
+  type HTMLFavolinkProps,
+  favolink,
+  forwardRef,
+} from '@favolink-ui/system';
+import { composeRefs, mergeFns } from '@favolink-ui/utils';
+import { useMenuContext } from './menu.context';
+
+export type MenuTriggerProps = HTMLFavolinkProps<'button'>;
+
+export const MenuTrigger = forwardRef<MenuTriggerProps, 'button'>(
+  function MenuTrigger(props, ref) {
+    const { children, onClick, ...restProps } = props;
+
+    const { triggerRef, onOpenChange, open } = useMenuContext();
+
+    return (
+      <favolink.button
+        {...restProps}
+        ref={composeRefs(ref, triggerRef)}
+        onClick={mergeFns(() => {
+          onOpenChange(!open);
+        }, onClick)}
+      >
+        {children}
+      </favolink.button>
+    );
+  },
+);

--- a/packages/ui/react/src/components/menu/menu.context.ts
+++ b/packages/ui/react/src/components/menu/menu.context.ts
@@ -1,0 +1,15 @@
+import { createContext } from '@favolink-ui/system';
+import { type Ref } from 'react';
+
+type MenuContextValue = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  triggerRef: Ref<HTMLButtonElement>;
+  containerRef: Ref<HTMLDivElement>;
+};
+
+export const [MenuProvider, useMenuContext] = createContext<MenuContextValue>({
+  name: 'MenuContentContext',
+  hookName: 'useMenuContentContext',
+  providerName: '<MenuContentProvider />',
+});

--- a/packages/ui/react/src/components/menu/menu.tsx
+++ b/packages/ui/react/src/components/menu/menu.tsx
@@ -1,0 +1,29 @@
+import { type ReactNode, useRef, useState } from 'react';
+import { MenuProvider } from './menu.context';
+
+export type MenuProps = {
+  children: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+export function Menu(props: MenuProps) {
+  const {
+    children,
+    open: onExternalOpen,
+    onOpenChange: onExternalOnOpenChange,
+  } = props;
+
+  const [onInternalOpen, onInternalOnOpenChange] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const open = onExternalOpen ?? onInternalOpen;
+  const onOpenChange = onExternalOnOpenChange ?? onInternalOnOpenChange;
+
+  return (
+    <MenuProvider value={{ open, onOpenChange, triggerRef, containerRef }}>
+      {children}
+    </MenuProvider>
+  );
+}


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #99 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* 메뉴 관련 모든 컴포넌트 및 컨텍스트를 추가합니다.

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

## 활용법

```tsx
      <Menu>
        <MenuTrigger>hello</MenuTrigger>
        <MenuPortal>
          <MenuContent placement="bottom">
            <Button>hhelo</Button>
            <Button>hhelo</Button>
            <Button>hhelo</Button>
            <Button>hhelo</Button>
          </MenuContent>
        </MenuPortal>
      </Menu>
```

* Menu에 open, onOpenChange 속성을 추가할 수 있습니다. 만약 추가하지 않으면 내부적으로 자동으로 동작합니다.
* MenuContent에 placement, sideOffset를 추가할수 있습니다. type은 다음과 같습니다.
* 모든 Menu 컴포넌트는 as, asChild 속성을 받아 변형시킬 수 있습니다.

```ts
type Layout = 'bottom' | 'left' | 'right' | 'top';

type Side = 'end' | 'start';

type SideOffset = number;

export type Placement = Layout | `${Layout}-${Side}`;
```
추후 개선사항이 생기면 수정하도록 하겠습니다.