### PR TITLE
feat(ui/react/typography/text): Text 컴포넌트 개편(as 속성, Slot)

### DIFF
--- a/packages/ui/react/src/components/typography/text.tsx
+++ b/packages/ui/react/src/components/typography/text.tsx
@@ -1,23 +1,35 @@
-import {
-  type HTMLFavolinkProps,
-  favolink,
-  forwardRef,
-} from '@favolink-ui/system';
+import { type HTMLFavolinkProps, Slot, forwardRef } from '@favolink-ui/system';
 import { cx } from '@favolink-ui/utils';
 import * as styles from './text.styles.css';
 
-export type TextProps = HTMLFavolinkProps<'p'> & styles.TextVariants;
+type TextDivProps = HTMLFavolinkProps<'div'> & { as: 'div' };
 
-export const Text = forwardRef<TextProps, 'p'>(function Text(props, ref) {
-  const { children, className, scale, ...restProps } = props;
+type TextLabelProps = HTMLFavolinkProps<'label'> & { as: 'label' };
+
+type TextPProps = HTMLFavolinkProps<'p'> & { as: 'p' };
+
+type TextSpanProps = HTMLFavolinkProps<'span'> & { as?: 'span' };
+
+export type TextProps = styles.TextVariants &
+  (TextDivProps | TextLabelProps | TextPProps | TextSpanProps);
+
+export const Text = forwardRef<TextProps, 'span'>(function Text(props, ref) {
+  const {
+    children,
+    className,
+    scale,
+    asChild,
+    as: Tag = 'span',
+    ...restProps
+  } = props;
 
   return (
-    <favolink.p
+    <Slot
       {...restProps}
       ref={ref}
       className={cx('favolink-text', styles.text({ scale }), className)}
     >
-      {children}
-    </favolink.p>
+      {asChild ? children : <Tag>{children}</Tag>}
+    </Slot>
   );
 });

--- a/packages/ui/react/src/components/typography/text.tsx
+++ b/packages/ui/react/src/components/typography/text.tsx
@@ -13,23 +13,25 @@ type TextSpanProps = HTMLFavolinkProps<'span'> & { as?: 'span' };
 export type TextProps = styles.TextVariants &
   (TextDivProps | TextLabelProps | TextPProps | TextSpanProps);
 
-export const Text = forwardRef<TextProps, 'span'>(function Text(props, ref) {
-  const {
-    children,
-    className,
-    scale,
-    asChild,
-    as: Tag = 'span',
-    ...restProps
-  } = props;
+export const Text = forwardRef<TextProps, 'span'>(
+  function Text(props, forwardedRef) {
+    const {
+      children,
+      className,
+      scale,
+      asChild,
+      as: Tag = 'span',
+      ...restProps
+    } = props;
 
-  return (
-    <Slot
-      {...restProps}
-      ref={ref}
-      className={cx('favolink-text', styles.text({ scale }), className)}
-    >
-      {asChild ? children : <Tag>{children}</Tag>}
-    </Slot>
-  );
-});
+    return (
+      <Slot
+        {...restProps}
+        ref={forwardedRef}
+        className={cx('favolink-text', styles.text({ scale }), className)}
+      >
+        {asChild ? children : <Tag>{children}</Tag>}
+      </Slot>
+    );
+  },
+);


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #229 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* div, span, p, label로 태그를 선택할 수 있게 as를 추가합니다.
* 외부 ref를 forwardRef 함수를 통해 받아오기 때문에 forwardRef 함수 내부 ref를 명확성을 위해 forwardedRef로 변경합니다.
* asChild인 상황을 대비하기 위해 Slot를 Text 내부 추가합니다

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

* as가 undefined일시 span으로 고정하여 as가 사용되지 않았을 경우 span을 받도록 합니다.
* label, div, span, p 태그가 올 수 있기 때문에 Slot 컴포넌트를 활용하여 변화 가능한 Tag로 모든 restProps를 받을 수 있도록 합니다. 만약 asChild가 사용된 경우 자식 node로 모든 restProps를 통합시킵니다.
