### PR TITLE
feat(ui/hooks): useCallbackRef hook 추가

### DIFF
--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @stylistic/padding-line-between-statements */
 export { useBoolean } from './use-boolean';
+export { useCallbackRef } from './use-callback-ref';
 export { useDisclosure } from './use-disclosure';
 export { useLayoutEffect } from './use-layout-effect';
 export { usePosition, type Placement } from './use-position';

--- a/packages/ui/src/hooks/use-callback-ref.ts
+++ b/packages/ui/src/hooks/use-callback-ref.ts
@@ -1,0 +1,13 @@
+import { useEffect, useMemo, useRef } from 'react';
+
+export function useCallbackRef<T extends (...args: any[]) => any>(
+  callback: T | undefined,
+): T {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  return useMemo(() => ((...args) => callbackRef.current?.(...args)) as T, []);
+}


### PR DESCRIPTION
## 이슈 번호 
<!-- 관련 이슈 번호를 적어주세요. -->

- close #298 

## 작업한 목록을 작성해 주세요
<!-- 커밋이나 구현한 작업 목록을 간단하고 명확하게 작성해 주세요. -->

* 이슈 내용과 같습니다.

## 스크린샷 
<!-- 해당하는 경우 문제를 설명하는 데 도움이 되는 스크린샷이나 비디오를 추가해 주세요. -->



## pr 포인트나 궁금한 점을 작성해 주세요 
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용이나 작업 중 의문이 들었던 점을 작성해 주세요. -->

```tsx
// useMemo 사용

return useMemo(() => ((...args) => callbackRef.current?.(...args)) as T, []);

// useCallback 사용

// eslint-disable-next-line react-hooks/exhaustive-deps
return useCallback(((...args) => callbackRef.current?.(...args)) as T, []);
```
<img width="880" alt="image" src="https://github.com/user-attachments/assets/d64aa7d0-d8f7-4e15-8bca-9c1032c7dacc">

*  [react 공식문서를 참고하자면](https://react.dev/reference/react/useCallback#how-is-usecallback-related-to-usememo) `useMemo`를 써도, `useCallback`을 써도 목적은 **함수 자체를 캐싱하기 위한 것**이기 때문에 위 두 코드는 같은 결과를 뱉습니다. useCallback을 쓴 경우 위와 같이 eslint `react-hooks/exhaustive-deps` 규칙에 경고가 나오기 때문에 피하기 위해 `useMemo`를 사용하였습니다.

